### PR TITLE
[v3] Prepare for v3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+
+  # Keep dependencies for GitHub Actions up-to-date
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/.github/workflows/configlet.yml
+++ b/.github/workflows/configlet.yml
@@ -13,4 +13,4 @@ jobs:
       uses: exercism/github-actions/configlet-ci@main
         
     - name: Configlet Linter
-      run: configlet lint .
+      run: configlet lint

--- a/.github/workflows/configlet.yml
+++ b/.github/workflows/configlet.yml
@@ -1,0 +1,16 @@
+name: Configlet CI
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  configlet:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+
+    - name: Fetch configlet
+      uses: exercism/github-actions/configlet-ci@main
+        
+    - name: Configlet Linter
+      run: configlet lint .

--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -1,32 +1,58 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-LATEST=https://github.com/exercism/configlet/releases/latest
+set -eo pipefail
 
-OS=$(
-case $(uname) in
-    (Darwin*)
-        echo "mac";;
-    (Linux*)
-        echo "linux";;
-    (Windows*)
-        echo "windows";;
-    (*)
-        echo "linux";;
-esac)
+readonly LATEST='https://api.github.com/repos/exercism/configlet/releases/latest'
 
-ARCH=$(
-case $(uname -m) in
-    (*64*)
-        echo 64bit;;
-    (*686*)
-        echo 32bit;;
-    (*386*)
-        echo 32bit;;
-    (*)
-        echo 64bit;;
-esac)
+case "$(uname)" in
+  Darwin*)   os='mac'     ;;
+  Linux*)    os='linux'   ;;
+  Windows*)  os='windows' ;;
+  MINGW*)    os='windows' ;;
+  MSYS_NT-*) os='windows' ;;
+  *)         os='linux'   ;;
+esac
 
-VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
-URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
+case "${os}" in
+  windows*) ext='zip' ;;
+  *)        ext='tgz' ;;
+esac
 
-curl -s --location $URL | tar xz -C bin/
+case "$(uname -m)" in
+  *64*)  arch='64bit' ;;
+  *686*) arch='32bit' ;;
+  *386*) arch='32bit' ;;
+  *)     arch='64bit' ;;
+esac
+
+curlopts=(
+  --silent
+  --show-error
+  --fail
+  --location
+  --retry 3
+)
+
+if [[ -n "${GITHUB_TOKEN}" ]]; then
+  curlopts+=(--header "authorization: Bearer ${GITHUB_TOKEN}")
+fi
+
+suffix="${os}-${arch}.${ext}"
+
+get_download_url() {
+  curl "${curlopts[@]}" --header 'Accept: application/vnd.github.v3+json' "${LATEST}" |
+    grep "\"browser_download_url\": \".*/download/.*/configlet.*${suffix}\"$" |
+    cut -d'"' -f4
+}
+
+download_url="$(get_download_url)"
+output_dir="bin"
+output_path="${output_dir}/latest-configlet.${ext}"
+curl "${curlopts[@]}" --output "${output_path}" "${download_url}"
+
+case "${ext}" in
+  *zip) unzip "${output_path}" -d "${output_dir}"   ;;
+  *)    tar xzf "${output_path}" -C "${output_dir}" ;;
+esac
+
+rm -f "${output_path}"

--- a/config.json
+++ b/config.json
@@ -22,5 +22,6 @@
     "concept": [],
     "practice": []
   },
-  "concepts": []
+  "concepts": [],
+  "key_features": []
 }

--- a/config.json
+++ b/config.json
@@ -11,6 +11,10 @@
   },
   "blurb": "",
   "version": 3,
+  "online_editor": {
+    "indent_style": "space",
+    "indent_size": 4
+  },
   "ignore_pattern": "[Ee]xample",
   "solution_pattern": "[Ee]xample",
   "test_pattern": "[Tt]est",

--- a/config.json
+++ b/config.json
@@ -23,5 +23,6 @@
     "practice": []
   },
   "concepts": [],
-  "key_features": []
+  "key_features": [],
+  "tags": []
 }

--- a/config.json
+++ b/config.json
@@ -19,6 +19,7 @@
   "solution_pattern": "[Ee]xample",
   "test_pattern": "[Tt]est",
   "exercises": {
+    "concept": [],
     "practice": []
   }
 }

--- a/config.json
+++ b/config.json
@@ -18,5 +18,7 @@
   "ignore_pattern": "[Ee]xample",
   "solution_pattern": "[Ee]xample",
   "test_pattern": "[Tt]est",
-  "exercises": []
+  "exercises": {
+    "practice": []
+  }
 }

--- a/config.json
+++ b/config.json
@@ -18,5 +18,5 @@
   "ignore_pattern": "[Ee]xample",
   "solution_pattern": "[Ee]xample",
   "test_pattern": "[Tt]est",
-  "exercises": null
+  "exercises": []
 }

--- a/config.json
+++ b/config.json
@@ -21,5 +21,6 @@
   "exercises": {
     "concept": [],
     "practice": []
-  }
+  },
+  "concepts": []
 }

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
   "track_id": "forth",
   "language": "Forth",
+  "slug": "forth",
   "active": false,
   "status": {
     "concept_exercises": false,

--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
   "language": "Forth",
   "active": false,
   "blurb": "",
+  "version": 3,
   "ignore_pattern": "[Ee]xample",
   "solution_pattern": "[Ee]xample",
   "test_pattern": "[Tt]est",

--- a/config.json
+++ b/config.json
@@ -2,6 +2,12 @@
   "track_id": "forth",
   "language": "Forth",
   "active": false,
+  "status": {
+    "concept_exercises": false,
+    "test_runner": false,
+    "representer": false,
+    "analyzer": false
+  },
   "blurb": "",
   "version": 3,
   "ignore_pattern": "[Ee]xample",


### PR DESCRIPTION
_This issue is part of the migration to v3. You can read full details about the various changes [here](https://github.com/exercism/v3-launch/)._

This PR prepares the track for Exercism v3, which will be different in a number of ways from Exercism v2. 

As having this PR merged is essential to prepare this track for Exercism v3, we'll automatically merge this PR one week after it was opened (if it hasn't been merged already). 

In this PR, the following changes are made:

## v2 file migration

1. Move the existing exercises in the `exercises` directory to the `exercises/practice` directory

## v3 file migration

1. Copy the v3 `languages/<slug>/concepts` directory to the `concepts` directory
1. Copy the v3 `languages/<slug>/exercises/concept` directory to the `exercises/concept` directory
1. Copy the v3 `languages/<slug>/reference` directory to the `reference` directory
1. Copy the v3 `languages/<slug>/docs` directory to the `docs` directory

### Notes

Any commits modifying the aforementioned directories (or any of their files) are included in the PR, except for:

- The `_sidebar.md` files are not migrated
- The `README.md` file at the v3 track's root is not migrated.
- The `maintainers.md` file is not migrated.

## config.json migration

The `config.json` file is updated to conform to the [v3 spec](https://github.com/exercism/v3-docs/blob/main/anatomy/tracks/config-json.md).

1. Add a version property:

```json
"version": 3
```

2. Add online editor settings:

```json
"online_editor": {
  "indent_style": "space",
  "indent_size": 2
}
```

3. Rename the `"exercises"` property to `"practice"`

4. Create an `"exercises"` property and move the `"practice"` property to this property:

```json
"exercises": {
  "practice": [
    ...
  ]
}
```

5. Remove the `"core"`, `"auto_approve"`, and `"unlocked_by"` properties from the practice exercises

6. Add the `"name"` property to the practice exercises and pre-populate this with a titlelized version of the `"slug"` property

7. Add the `"prerequisites"` property to the practice exercises and set it to an empty array

8. Add an empty `"concept"` array property to the `"exercises"` property

```json
"exercises": {
  "concept": [],
  "practice": [
    ...
  ]
}
```

9. Move the `"foregone"` property to the `"exercises"` key:

```json
"exercises": {
  ...
  "foregone": [...]
}
```

10. Add a top-level `"concepts"` key, which is an array:

```json
"concepts": []
```

11. Add a top-level `"tags"` key, which is an array:

```json
"tags": []
```

12. Add a top-level `"key_features"` key, which is an array:

```json
"key_features": []
```

13. Add a top-level `"status"` key, which is an object containing properties with boolean values indicating if a v3 feature is implemented:

```json
"status": {
  "concept_exercises": true,
  "test_runner": true,
  "representer": false,
  "analyzer": false
}
```

14. Add a top-level `"slug"` key, which is a string containing the track's slug:

```json
"slug": "csharp"
```

15. Re-order the practice exercises using the following ordering:

    1. Core exercises, retaining their existing ordering
    2. Non-core exercises, ordered by the order of the core exercise that unlocks them, then by difficulty and then alphabetically.
    3. Bonus exercises, ordered by difficulty then alphabetically.

16. Add the `"status"` key with a value of `"deprecated"` to practice exercises that have `"deprecated"` set to `true`. The `deprecated` field itself is removed:

```json
{
  "slug": "octal",
  "name": "Octal",
  "uuid": "f29f9e56-c79b-4ae4-a0d0-29db78c677e4",
  "prerequisites": [],
  "difficulty": 0,
  "topics": ["integers"],
  "status": "deprecated"
}
```

### Notes

- Settings defined in the v3 `config.json` file will take precedence over their v2 `config.json` file's equivalent.

## configlet

1. Update the `fetch-configlet` and `fetch-configlet.ps1` files to the latest version of [configlet](https://github.com/exercism/configlet), which can work with v3 tracks.

## Continuous integration

1. Add a GitHub Actions workflow to verify the track using the [configlet-CI GitHub Action](https://github.com/exercism/github-actions/tree/main/configlet-ci), unless there already is a file named `.github/workflows/configlet.md`.

1. Add a [dependabot configuration](https://dependabot.com/github-actions/) to automatically submit PRs for any new versions of external workflows used in this track's GitHub Action workflows.

1. Convert any Exercism GitHub Actions workflows being used to use `main` as their branch instead of `master`. See [this issue](https://github.com/exercism/github-actions/issues/14).

## Follow-up steps

We've created issues in this repo for the follow-up steps to get this track ready for v3.

## Tracking

https://github.com/exercism/v3-launch/issues/11